### PR TITLE
Changed bet history cards and fixed some errors

### DIFF
--- a/src/components/Profile/BetHistoryCard.js
+++ b/src/components/Profile/BetHistoryCard.js
@@ -4,6 +4,7 @@ import Box from "@mui/material/Box";
 import CardContent from "@mui/material/CardContent";
 import {MlbTeamPics} from "../Shared/MlbTeamPicDict";
 import {Typography} from "@mui/material";
+import {convertDate} from "../Shared/UtilFunctions";
 
 const BetHistoryCard = ({gameData}) => {
     // Change this to actual colors later
@@ -51,6 +52,32 @@ const BetHistoryCard = ({gameData}) => {
                     gap={2}
                 >
                     <Box sx={{justifySelf: "center"}} gridColumn="span 2">
+                        <img
+                            src={MlbTeamPics[gameData.game_away_team]}
+                            alt={gameData.game_away_team}
+                            height={
+                                gameData.bet_team === gameData.game_away_team
+                                    ? "60px"
+                                    : "50px"
+                            }
+                            style={
+                                gameData.bet_team === gameData.game_away_team
+                                    ? teamBetStyle
+                                    : null
+                            }
+                        />
+                        <br />
+                        <Typography variant="h6">
+                            {gameData.game_away_moneyline}
+                        </Typography>
+                    </Box>
+                    <Box
+                        sx={{alignSelf: "center", justifySelf: "center"}}
+                        gridColumn="span 2"
+                    >
+                        VS
+                    </Box>
+                    <Box sx={{justifySelf: "center"}} gridColumn="span 2">
                         {" "}
                         <img
                             src={MlbTeamPics[gameData.game_home_team]}
@@ -71,36 +98,20 @@ const BetHistoryCard = ({gameData}) => {
                             {gameData.game_home_moneyline}
                         </Typography>
                     </Box>
-
-                    <Box
-                        sx={{alignSelf: "center", justifySelf: "center"}}
-                        gridColumn="span 2"
-                    >
-                        VS
-                    </Box>
-
-                    <Box sx={{justifySelf: "center"}} gridColumn="span 2">
-                        <img
-                            src={MlbTeamPics[gameData.game_away_team]}
-                            alt={gameData.game_away_team}
-                            height={
-                                gameData.bet_team === gameData.game_away_team
-                                    ? "60px"
-                                    : "50px"
-                            }
-                            style={
-                                gameData.bet_team === gameData.game_away_team
-                                    ? teamBetStyle
-                                    : null
-                            }
-                        />
-                        <br />
-                        <Typography variant="h6">
-                            {gameData.game_away_moneyline}
-                        </Typography>
-                    </Box>
                 </Box>
-                {gameData.game_is_completed && (
+                <Box
+                    sx={{
+                        display: "flex",
+                        justifyContent: "center",
+                        justifySelf: "center",
+                        flexWrap: "nowrap",
+                    }}
+                >
+                    <Typography variant="p">
+                        {convertDate(gameData.game_start_time)}
+                    </Typography>
+                </Box>
+                {gameData.game_is_completed ? (
                     <Box
                         sx={{
                             display: "flex",
@@ -109,10 +120,23 @@ const BetHistoryCard = ({gameData}) => {
                             flexWrap: "nowrap",
                         }}
                     >
-                        <p>
+                        <Typography variant="p">
                             You {["lost", "won"][+gameData.bet_success]}:&nbsp;$
                             {getBetHistoryDollarAmount()?.toFixed(2) ?? "ERR"}.
-                        </p>
+                        </Typography>
+                    </Box>
+                ) : (
+                    <Box
+                        sx={{
+                            display: "flex",
+                            justifyContent: "center",
+                            justifySelf: "center",
+                            flexWrap: "nowrap",
+                        }}
+                    >
+                        <Typography variant="p">
+                            Bet amount: ${gameData.bet_amount?.toFixed(2)}
+                        </Typography>
                     </Box>
                 )}
             </CardContent>

--- a/src/components/Profile/BetHistoryCardGallery.js
+++ b/src/components/Profile/BetHistoryCardGallery.js
@@ -11,8 +11,8 @@ const BetHistoryCardGallery = ({bets}) => {
                 justifyContent: "center",
             }}
         >
-            {bets.map((bet) => (
-                <BetHistoryCard gameData={bet} />
+            {bets.map((bet, index) => (
+                <BetHistoryCard key={`betHistoryCard${index}`} gameData={bet} />
             ))}
         </Box>
     );

--- a/src/components/Profile/ProfileBetTabs.jsx
+++ b/src/components/Profile/ProfileBetTabs.jsx
@@ -4,27 +4,23 @@ import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 
 export default function ProfileBetTab(props) {
-	const { children, value, index, ...other } = props;
+    const {children, value, index, ...other} = props;
 
-	return (
-		<div
-			role="tabpanel"
-			hidden={value !== index}
-			id={`bet-tabpanel-${index}`}
-			aria-labelledby={`bet-tab-${index}`}
-			{...other}
-		>
-			{value === index && (
-				<Box sx={{ p: 2 }}>
-					<Typography>{children}</Typography>
-				</Box>
-			)}
-		</div>
-	);
+    return (
+        <div
+            role="tabpanel"
+            hidden={value !== index}
+            id={`bet-tabpanel-${index}`}
+            aria-labelledby={`bet-tab-${index}`}
+            {...other}
+        >
+            {value === index && <Box sx={{p: 2}}>{children}</Box>}
+        </div>
+    );
 }
 
 ProfileBetTab.propTypes = {
-	children: PropTypes.node,
-	index: PropTypes.number.isRequired,
-	value: PropTypes.number.isRequired,
+    children: PropTypes.node,
+    index: PropTypes.number.isRequired,
+    value: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
- Fixed bet tabs wrapped in typography tag for some reason.
- Home team is now on the right side of the bet history cards.
- Date of game? bet? is now listed on the cards.
- Current bets now have amount listed on them instead of won/lost amounts.
- Fixed BetHistoryGallery not giving the bet history cards a key prop, causing lint errors.